### PR TITLE
Fix input handling for model predictions in notebook

### DIFF
--- a/notebooks/examples/original_implementation.ipynb
+++ b/notebooks/examples/original_implementation.ipynb
@@ -537,7 +537,7 @@
         "#The Dense function in Keras constructs a fully connected neural network layer, automatically initializing the weights as biases.\n",
         "#First hidden layer\n",
         "model = Sequential()\n",
-        "model.add(Dense(64, activation='relu'))\n",
+        "model.add(Dense(64, activation='relu', input_shape=(1,)))\n",
         "model.add(Dense(64, activation='relu'))\n",
         "model.add(Dense(1))"
       ],
@@ -560,11 +560,11 @@
         "              loss=loss,\n",
         "              metrics=['mae'], #Mean Absolute Error\n",
         "             )\n",
-        "history = model.fit(X_in_train, X_out_train, \n",
+        "history = model.fit(X_in_train.values.reshape(-1, 1), X_out_train.values, \n",
         "                    shuffle=True, \n",
         "                    epochs=epochs,\n",
         "                    batch_size=20,\n",
-        "                    validation_data=(X_in_test, X_out_test), \n",
+        "                    validation_data=(X_in_test.values.reshape(-1, 1), X_out_test.values), \n",
         "                    verbose=1)"
       ],
       "execution_count": null,
@@ -905,7 +905,7 @@
         "                                 ), \n",
         "                        line_color='crimson'))\n",
         "fig.add_trace(go.Scatter(x = X_in_train, \n",
-        "                         y=model.predict(X_in_train).reshape(-1),\n",
+        "                         y=model.predict(X_in_train.values.reshape(-1, 1)).ravel(),\n",
         "                         mode='lines',\n",
         "                         name=f'Trained Capacity',\n",
         "                         line=dict(color='navy', width=3)))\n",
@@ -997,7 +997,7 @@
         "outputId": "52c95c9b-d4b2-4103-fe3b-85fcce2f607c"
       },
       "source": [
-        "X_twin = X_in + model.predict(X_in).reshape(-1)\n",
+        "X_twin = X_in.values + model.predict(X_in.values.reshape(-1, 1)).ravel()\n",
         "\n",
         "fig = go.Figure()\n",
         "\n",
@@ -1122,7 +1122,7 @@
         "K = 0.13\n",
         "L_e = 1-e**(-K*cycles*temperature/time)\n",
         "X_in_e = -(L_e*dfb['Capacity'].iloc[0:1].values[0]) + dfb['Capacity'].iloc[0:1].values[0]\n",
-        "C_twin_e = X_in_e + model.predict(X_in_e).reshape(-1)"
+        "C_twin_e = X_in_e + model.predict(X_in_e.reshape(-1, 1)).ravel()"
       ],
       "execution_count": null,
       "outputs": []
@@ -1138,7 +1138,7 @@
         "outputId": "0840db8c-cb67-4a77-cb1e-dedfb990b2d8"
       },
       "source": [
-        "X_twin = X_in + model.predict(X_in).reshape(-1)\n",
+        "X_twin = X_in.values + model.predict(X_in.values.reshape(-1, 1)).ravel()\n",
         "\n",
         "fig = go.Figure()\n",
         "\n",


### PR DESCRIPTION
The model is trained on a pandas Series (X_in = dfb['C. Capacity']), which Keras silently expands to shape (n, 1). At extrapolation time X_in_e is a plain 1-D numpy array of shape (n,), which is not expanded — so Dense rejects it with expected min_ndim=2, found ndim=1.