### PR TITLE
docs: fix broken install, non-running snippets and dead URLs

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -137,7 +137,7 @@ twin = DigitalTwin(model=sys)
 result = twin.forecast(x0, t, u)
 
 # Energy should decay exponentially with damping
-import matplotlib.pyplot as plt
+import matplotlib.pyplot as plt   # requires: pip install "otwin[viz]"
 energies = [sys.energy(x) for x in result['x']]
 plt.plot(result['t'], energies)
 plt.xlabel('Time (s)')
@@ -210,16 +210,16 @@ With `u = 0`, energy is non-increasing → **passive system**.
 ### Why This Matters
 
 **Traditional neural ODEs:**
-```python
-dx = neural_net(x, u)  # No structure
+```text
+dx = neural_net(x, u)          # no structure
 ```
 → Can violate physics, create energy, drift on long horizons
 
 **Port-Hamiltonian neural networks (Phase 4):**
-```python
+```text
 dx = (J_θ(x) − R_θ(x)) ∇H_θ(x) + g_θ(x) u
-# J_θ = A_θ − A_θᵀ  (skew by construction)
-# R_θ = L_θ @ L_θᵀ  (PSD by construction)
+J_θ = A_θ − A_θᵀ   (skew by construction)
+R_θ = L_θ L_θᵀ   (PSD by construction)
 ```
 → **Structure enforced regardless of learned weights**
 → No energy-creating drift, by algebra

--- a/README.md
+++ b/README.md
@@ -152,12 +152,17 @@ twin = DigitalTwin(model=water_tank())
 
 # 2. Forecast from an initial state x0 over a time grid t with inputs u
 x0 = np.array([1.0])
-t  = np.linspace(0, 10, 100)
-u  = np.zeros((100, 1))
+t  = np.linspace(0, 30, 300)
+u  = np.zeros((300, 1))
 fc = twin.forecast(x0, t, u)
-print(fc["x"].shape)            # (100, 1)
+print(fc["x"].shape)            # (300, 1)
 
 # 3. Validate with a leakage-free protocol + mandatory baselines
+#    `data` is your measured series, shape (n_samples, n_features).
+#    Here we stand in for it with the model output plus measurement noise.
+rng  = np.random.default_rng(0)
+data = fc["x"] + rng.normal(0, 0.01, fc["x"].shape)
+
 report = evaluate(twin, data, protocol="rolling_origin")
 print(report)                   # skill score vs naive baseline, first
 ```

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -13,7 +13,7 @@ sys.path.insert(0, os.path.abspath('../src'))
 # -- Project information -----------------------------------------------------
 
 project = 'otwin'
-copyright = '2024, Javier Marin'
+copyright = '2026, Javier Marin'
 author = 'Javier Marin'
 release = '2.0.0-alpha'
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -5,7 +5,7 @@ Install (core is numpy + scipy only):
 
 .. code-block:: bash
 
-   pip install git+https://github.com/Javihaus/otwin.git@v2
+   pip install otwin
 
 Strong end — an analytic port-Hamiltonian system from the catalog:
 
@@ -26,6 +26,10 @@ Strong end — an analytic port-Hamiltonian system from the catalog:
 Evaluate with a leakage-free protocol and mandatory baselines:
 
 .. code-block:: python
+
+   # `data` is your measured series, shape (n_samples, n_features)
+   rng = np.random.default_rng(0)
+   data = forecast["x"] + rng.normal(0, 0.01, forecast["x"].shape)
 
    report = evaluate(twin, data, protocol="rolling_origin")
    print(report)                         # skill score vs naive baseline, first

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,7 +86,7 @@ dev = [
 
 [project.urls]
 Homepage = "https://github.com/Javihaus/otwin"
-Documentation = "https://github.com/Javihaus/otwin/docs"
+Documentation = "https://github.com/Javihaus/otwin/tree/main/docs"
 Repository = "https://github.com/Javihaus/otwin.git"
 Issues = "https://github.com/Javihaus/otwin/issues"
 


### PR DESCRIPTION
- quickstart.rst installed a git tag (@v2) that does not exist in the repo
- README and quickstart evaluate() snippets referenced an undefined data
- README example raised a rolling-origin fold warning at 100 samples
- PHS equations were fenced as python but contain U+2212 and nabla (SyntaxError)
- pyproject Documentation URL pointed at a non-existent GitHub path
- note the [viz] extra where matplotlib is imported